### PR TITLE
feat: add `enum` attribute to allow the use of fieldless enums

### DIFF
--- a/derive/src/case.rs
+++ b/derive/src/case.rs
@@ -1,5 +1,5 @@
 //! This file is based on MIT license from serde project
-//! https://github.com/serde-rs/serde
+//! <https://github.com/serde-rs/serde>
 //!
 //! Code to convert the Rust-styled field/variant (e.g. `my_field`, `MyType`) to the
 //! case of the source (e.g. `my-field`, `MY_FIELD`).

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -279,7 +279,7 @@ fn parse_attrs(attrs: &[Attribute]) -> AttrMeta {
                     require = true;
                 } else if token_str == "skip" {
                     skip = true;
-                } else if token_str == "is_enum" {
+                } else if token_str == "is_enum" || token_str == "enum" {
                     is_enum = true;
                 } else {
                     abort!(&attr, format!("{} is not allowed attribute", token_str))

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -800,6 +800,48 @@ a = 0
     }
 
     #[test]
+    fn is_enum() {
+        fn b() -> AB {
+            AB::B
+        }
+        #[derive(TomlExample, Deserialize, Default, PartialEq, Debug)]
+        #[allow(dead_code)]
+        struct Config {
+            /// Config.ab is an enum
+            #[toml_example(is_enum)]
+            #[toml_example(default)]
+            ab: AB,
+            /// Config.ab2 is an enum too
+            #[toml_example(is_enum)]
+            #[serde(default)]
+            ab2: AB,
+            /// Config.ab3 is an enum as well
+            #[toml_example(is_enum)]
+            #[serde(default = "b")]
+            ab3: AB,
+        }
+        #[derive(Debug, Default, Deserialize, PartialEq)]
+        enum AB {
+            #[default]
+            A,
+            B,
+        }
+        assert_eq!(
+            Config::toml_example(),
+            r#"# Config.ab is an enum
+ab = "A"
+
+# Config.ab2 is an enum too
+ab2 = "A"
+
+# Config.ab3 is an enum as well
+ab3 = "B"
+
+"#
+        );
+    }
+
+    #[test]
     fn r_sharp_field() {
         #[derive(TomlExample)]
         #[allow(dead_code)]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -839,7 +839,7 @@ a = 0
         #[allow(dead_code)]
         struct Config {
             /// Config.ab is an enum
-            #[toml_example(is_enum)]
+            #[toml_example(enum)]
             #[toml_example(default)]
             ab: AB,
             /// Config.ab2 is an enum too

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -114,6 +114,37 @@
 //!
 //! "#)
 //! ```
+//!
+//! You can also use fieldless enums, but you have to annotate them with `#[toml_example(enum)]` or
+//! `#[toml_example(is_enum)]` if you mind the keyword highlight you likely get when writing
+//! "enum".<br>
+//! When annotating a field with `#[toml_example(default)]` it will use the
+//! [Debug](core::fmt::Debug) implementation.
+//! However for non-TOML datatypes like enums, this does not work as the value needs to be treated
+//! as a string in TOML. The `#[toml_example(enum)]` attribute just adds the needed quotes around
+//! the [Debug](core::fmt::Debug) implementation and can be omitted if a custom
+//! [Debug](core::fmt::Debug) already includes those.
+//! ```rust
+//! use toml_example::TomlExample;
+//! #[derive(TomlExample)]
+//! struct Config {
+//!     /// Config.priority is an enum
+//!     #[toml_example(default)]
+//!     #[toml_example(enum)]
+//!     priority: Priority,
+//! }
+//! #[derive(Debug, Default)]
+//! enum Priority {
+//!     #[default]
+//!     Important,
+//!     Trivial,
+//! }
+//! assert_eq!(Config::toml_example(),
+//! r#"# Config.priority is an enum
+//! priority = "Important"
+//!
+//! "#)
+//! ```
 
 #[doc(hidden)]
 pub use toml_example_derive::TomlExample;


### PR DESCRIPTION
this will close #38  

Todo:
- [x] add some test
- [x] mention the new `#[toml_example(is_enum)]` in the docs
- [x] ~~be sure that `is_enum` is the best name for it~~ support both `enum` and `is_enum`