### PR TITLE
feat: respect outer default attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,21 @@ A lib help generate toml example
 This crate provides the `TomlExample` trait and an accompanying derive macro.
 
 Deriving `TomlExample` on a struct will provide `to_example` function help generate toml example file base documentation
-- support `#[serde(default)]`, `#[serde(default = "function_name")]` attributes (`serde` feature, opt-in)
+- support `#[serde(default)]`, `#[serde(default = "function_name")]` attributes on both structs and struct fields (`serde` feature, opt-in)
 - support `#[serde(rename)]`, `#[serde(rename_all = "renaming rules")]`, the renaming rules can be `lowercase`, `UPPERCASE`,
 `PascalCase`, `camelCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case`, `SCREAMING-KEBAB-CASE`
-- provide `#[toml_example(default)]`, `#[toml_example(default = 0)]`, `#[toml_example(default = "default_string")]` attributes
+- provide `#[toml_example(default)]`, `#[toml_example(default = 0)]`, `#[toml_example(default = "default_string")]` attributes on struct fields
+- `#[toml_example(default)]` is also supported as an outer attribute for structs
 - The order matter of attribute macro, if `#[serde(default = ..]` and `#[toml_example(default = ..)]` existing at the same time with different value
 
 ## Quick Example
 ```rust 
 use toml_example::TomlExample;
+use serde::Deserialize;
 
 /// Config is to arrange something or change the controls on a computer or other device
 /// so that it can be used in a particular way
-#[derive(TomlExample)]
+#[derive(TomlExample, Deserialize)]
 struct Config {
     /// Config.a should be a number
     a: usize,
@@ -84,6 +86,36 @@ g = 7
 # Config.h should be a string
 h = "seven"
 
+```
+
+The fields of a struct can inherit their defaults from the parent struct when the
+`#[toml_example(default)]`, `#[serde(default)]` or `#[serde(default = "default_fn")]`
+attribute is set as an outer attribute of the parent struct:
+
+```rust
+use serde::Serialize;
+use toml_example::TomlExample;
+
+#[derive(TomlExample, Serialize)]
+#[serde(default)]
+struct Config {
+    /// Name of the theme to use
+    theme: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            theme: String::from("Dark"),
+        }
+    }
+}
+
+assert_eq!(Config::toml_example(),
+r#"# Name of the theme to use
+theme = "Dark"
+
+"#);
 ```
 
 ## Nesting Struct

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,19 +10,19 @@
 //! /// so that it can be used in a particular way
 //! #[derive(TomlExample)]
 //! struct Config {
-//! /// Config.a should be a number
-//! a: usize,
-//! /// Config.b should be a string
-//! b: String,
-//! /// Optional Config.c is a number
-//! c: Option<usize>,
-//! /// Config.d is a list of number
-//! d: Vec<usize>,
-//! #[toml_example(default =7)]
-//! e: usize,
-//! /// Config.f should be a string
-//! #[toml_example(default = "seven")]
-//! f: String,
+//!     /// Config.a should be a number
+//!     a: usize,
+//!     /// Config.b should be a string
+//!     b: String,
+//!     /// Optional Config.c is a number
+//!     c: Option<usize>,
+//!     /// Config.d is a list of number
+//!     d: Vec<usize>,
+//!     #[toml_example(default =7)]
+//!     e: usize,
+//!     /// Config.f should be a string
+//!     #[toml_example(default = "seven")]
+//!     f: String,
 //! }
 //! assert_eq!( Config::toml_example(),
 //! r#"# Config is to arrange something or change the controls on a computer or other device
@@ -60,8 +60,8 @@
 //! /// Service with specific port
 //! #[derive(TomlExample)]
 //! struct Service {
-//! /// port should be a number
-//! #[toml_example(default = 80)]
+//!     /// port should be a number
+//!     #[toml_example(default = 80)]
 //!     port: usize,
 //! }
 //! #[derive(TomlExample)]
@@ -79,6 +79,35 @@
 //! [services.http]
 //! ## port should be a number
 //! port = 80
+//!
+//! "#);
+//! ```
+//!
+//! The `#[toml_example(default)]`, `#[serde(default)]` and `#[serde(default = "default_fn")]`
+//! attributes are also usable as outer attributes of a struct:
+//!
+//! ```rust
+//! use serde::Serialize;
+//! use toml_example::TomlExample;
+//!
+//! #[derive(TomlExample, Serialize)]
+//! #[serde(default)]
+//! struct Config {
+//!     /// Name of the theme to use
+//!     theme: String,
+//! }
+//!
+//! impl Default for Config {
+//!     fn default() -> Self {
+//!         Self {
+//!             theme: String::from("Dark"),
+//!         }
+//!     }
+//! }
+//!
+//! assert_eq!(Config::toml_example(),
+//! r#"# Name of the theme to use
+//! theme = "Dark"
 //!
 //! "#);
 //! ```

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -387,6 +387,53 @@ color = "#FAFAFA"
     }
 
     #[test]
+    fn struct_serde_default() {
+        #[derive(TomlExample, Deserialize, PartialEq)]
+        #[serde(default)]
+        struct Foo {
+            bar: String,
+        }
+        impl Default for Foo {
+            fn default() -> Self {
+                Foo {
+                    bar: String::from("hello world"),
+                }
+            }
+        }
+        assert_eq!(Foo::toml_example(), "bar = \"hello world\"\n\n");
+    }
+
+    #[test]
+    fn struct_serde_default_fn() {
+        #[derive(TomlExample, Deserialize, PartialEq)]
+        #[serde(default = "default")]
+        struct Foo {
+            bar: String,
+        }
+        fn default() -> Foo {
+            Foo {
+                bar: String::from("hello world"),
+            }
+        }
+        assert_eq!(Foo::toml_example(), "bar = \"hello world\"\n\n");
+    }
+
+    #[test]
+    fn struct_toml_example_default() {
+        #[derive(TomlExample, PartialEq)]
+        #[toml_example(default)]
+        struct Foo {
+            yay: &'static str,
+        }
+        impl Default for Foo {
+            fn default() -> Self {
+                Foo { yay: "no, paru!" }
+            }
+        }
+        assert_eq!(Foo::toml_example(), "yay = \"no, paru!\"\n\n");
+    }
+
+    #[test]
     fn no_nesting() {
         /// Inner is a config live in Outer
         #[derive(TomlExample, Deserialize, Default, PartialEq, Debug)]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -392,15 +392,25 @@ color = "#FAFAFA"
         #[serde(default)]
         struct Foo {
             bar: String,
+            #[serde(default)]
+            x: usize,
         }
         impl Default for Foo {
             fn default() -> Self {
                 Foo {
                     bar: String::from("hello world"),
+                    x: 12,
                 }
             }
         }
-        assert_eq!(Foo::toml_example(), "bar = \"hello world\"\n\n");
+        assert_eq!(
+            Foo::toml_example(),
+            r##"bar = "hello world"
+
+x = 0
+
+"##
+        );
     }
 
     #[test]
@@ -409,28 +419,53 @@ color = "#FAFAFA"
         #[serde(default = "default")]
         struct Foo {
             bar: String,
+            #[toml_example(default = "field override")]
+            baz: String,
         }
         fn default() -> Foo {
             Foo {
                 bar: String::from("hello world"),
+                baz: String::from("custom default"),
             }
         }
-        assert_eq!(Foo::toml_example(), "bar = \"hello world\"\n\n");
+        assert_eq!(
+            Foo::toml_example(),
+            r##"bar = "hello world"
+
+baz = "field override"
+
+"##
+        );
     }
 
     #[test]
     fn struct_toml_example_default() {
-        #[derive(TomlExample, PartialEq)]
+        #[derive(TomlExample, Deserialize, PartialEq)]
         #[toml_example(default)]
         struct Foo {
+            #[serde(default = "paru")]
             yay: &'static str,
+            aur_is_useful: bool,
         }
         impl Default for Foo {
             fn default() -> Self {
-                Foo { yay: "no, paru!" }
+                Foo {
+                    yay: "yay!",
+                    aur_is_useful: true,
+                }
             }
         }
-        assert_eq!(Foo::toml_example(), "yay = \"no, paru!\"\n\n");
+        fn paru() -> &'static str {
+            "no, paru!"
+        }
+        assert_eq!(
+            Foo::toml_example(),
+            r##"yay = "no, paru!"
+
+aur_is_useful = true
+
+"##
+        );
     }
 
     #[test]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -83,8 +83,9 @@
 //! "#);
 //! ```
 //!
-//! The `#[toml_example(default)]`, `#[serde(default)]` and `#[serde(default = "default_fn")]`
-//! attributes are also usable as outer attributes of a struct:
+//! The fields of a struct can inherit their defaults from the parent struct when the
+//! `#[toml_example(default)]`, `#[serde(default)]` or `#[serde(default = "default_fn")]`
+//! attribute is set as an outer attribute of the parent struct:
 //!
 //! ```rust
 //! use serde::Serialize;


### PR DESCRIPTION
this will close #42 
```rs
use serde::Serialize;
use toml_example::TomlExample;

fn main() {
    let example = Config::toml_example();
    println!("Example:\n{example}");
    let toml = toml::to_string(&Config::default()).unwrap();
    println!("Toml:\n{toml}");
}

#[derive(TomlExample, Serialize)]
#[serde(default)]
struct Config {
    /// Name of the theme to use
    theme: String,
}

impl Default for Config {
    fn default() -> Self {
        Self {
            theme: String::from("Dark"),
        }
    }
}
```

The output:
```
Example:
# Name of the theme to use
theme = "Dark"


Toml:
theme = "Dark"
```

This also works with `#[serde(default = "default_fn")]` and `#[toml_example(default)]`

## To-do:
- [x] Add test case
- [x] Update crate documentation
- [x] Update Readme
- [x] Rewrite [this](https://github.com/faervan/toml-example/blob/c5bbad8a78d3a8290efbd2adf58cb3a7d67ab679/derive/src/lib.rs#L481) so that `rustfmt` is able to format it within the max_line rule