### PR TITLE
feat: support HashSet and BTreeSet as TOML arrays

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -170,7 +170,7 @@ fn default_value(ty: String) -> String {
     .to_string()
 }
 
-/// return type and unwrap with Option and Vec; or return the value type of HashMap and BTreeMap
+/// return type and unwrap with Option, Vec, HashSet, BTreeSet; or return the value type of HashMap and BTreeMap
 fn parse_type(
     ty: &Type,
     default: &mut String,
@@ -194,7 +194,7 @@ fn parse_type(
                         r#type = parse_type(ty, default, &mut false, nesting_format);
                     }
                 }
-            } else if id == "Vec" {
+            } else if id == "Vec" || id == "HashSet" || id == "BTreeSet" {
                 if nesting_format.is_some() {
                     *nesting_format = Some(NestingFormat::Section(NestingType::Vec));
                 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -354,6 +354,36 @@ c = [ 0, ]
     }
 
     #[test]
+    fn hashset_btreeset() {
+        use std::collections::{BTreeSet, HashSet};
+
+        #[derive(TomlExample, Deserialize, Default, PartialEq, Debug)]
+        #[allow(dead_code)]
+        struct Config {
+            /// Config.a is a set of string
+            a: HashSet<String>,
+            /// Config.b is a set of number
+            b: BTreeSet<usize>,
+            /// Config.c is optional
+            c: Option<HashSet<String>>,
+        }
+        assert_eq!(
+            Config::toml_example(),
+            r#"# Config.a is a set of string
+a = [ "", ]
+
+# Config.b is a set of number
+b = [ 0, ]
+
+# Config.c is optional
+# c = [ "", ]
+
+"#
+        );
+        assert!(toml::from_str::<Config>(&Config::toml_example()).is_ok())
+    }
+
+    #[test]
     fn struct_doc() {
         /// Config is to arrange something or change the controls on a computer or other device
         /// so that it can be used in a particular way


### PR DESCRIPTION
## Summary

Extends `parse_type` in the derive macro to recognize `HashSet<T>` and `BTreeSet<T>` alongside `Vec<T>`. All three serialize to TOML arrays via serde, so the existing `Vec` codegen path applies unchanged.

## Motivation

Currently a struct field like `tags: HashSet<String>` fails to derive `TomlExample` (the type is silently ignored by `parse_type`, which then emits no example for the field). Users have to either rewrite the field as `Vec<String>` or write a manual `impl TomlExample`. This patch removes that friction without changing any existing behavior.

## Changes

- `derive/src/lib.rs`: change the `Vec` arm of `parse_type` to `Vec | HashSet | BTreeSet` and update the doc comment.
- `lib/src/lib.rs`: add `hashset_btreeset` test covering required `HashSet<String>`, `BTreeSet<usize>`, and `Option<HashSet<String>>`, with round-trip parse verification.

## Test plan

- [x] `cargo test --workspace` — all 38 tests pass (37 existing + 1 new)
- [x] New test verifies generated TOML round-trips through `toml::from_str`